### PR TITLE
Add court summaries

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { Toaster } from 'react-hot-toast';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import ScrollToTop from '@/components/ScrollToTop';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -26,6 +27,7 @@ export default function RootLayout({
         </main>
         <Footer />
         <Toaster />
+        <ScrollToTop />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ export default function Home() {
   const [selectedParkId, setSelectedParkId] = useState<string | null>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const mapRef = useRef<HTMLDivElement>(null);
 
   const handleDateChange = (date: Date | null) => {
     if (date) {
@@ -40,6 +41,12 @@ export default function Home() {
     const parkElement = document.getElementById(`park-${parkId}`);
     if (parkElement) {
       parkElement.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  const scrollToMap = () => {
+    if (mapRef.current) {
+      mapRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   };
 
@@ -181,7 +188,7 @@ export default function Home() {
 
         {/* Map Section */}
         {parks.length > 0 && (
-          <div className="mb-8">
+          <div className="mb-8" ref={mapRef}>
             <h2 className="text-xl font-semibold text-gray-900 mb-4">
               Tennis Courts Locations
             </h2>
@@ -256,6 +263,15 @@ export default function Home() {
                     ))}
                   </div>
                 </div>
+                <button
+                  onClick={scrollToMap}
+                  className="text-blue-600 hover:text-blue-800 text-sm flex items-center gap-1 px-3 py-1.5 rounded-md hover:bg-blue-50 transition-colors group"
+                  title="Go back to map"
+                  aria-label="Go back to map"
+                >
+                  <MapPinIcon className="h-5 w-5" />
+                  <span className="hidden group-hover:inline">View on map</span>
+                </button>
               </div>
             );
           }).filter(Boolean)}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -187,6 +187,7 @@ export default function Home() {
             </h2>
             <ParksMap
               parks={parks}
+              selectedDate={selectedDate}
               onParkClick={handleParkClick}
             />
           </div>

--- a/src/components/ParksMap.tsx
+++ b/src/components/ParksMap.tsx
@@ -15,6 +15,8 @@ interface SlotSummary {
 }
 
 function getSlotSummary(slots: TimeSlot[]): SlotSummary {
+  console.log('Calculating summary for slots:', slots);
+  
   return slots.reduce((summary, slot) => {
     // Parse time like "6:00 a.m." or "2:30 p.m."
     const timeComponents = slot.time.toLowerCase().split(' ');
@@ -30,13 +32,18 @@ function getSlotSummary(slots: TimeSlot[]): SlotSummary {
       hours = 0;
     }
 
+    console.log(`Processing slot: ${slot.time} -> ${hours}:${minutes} (${period})`);
+
     // Classify slots
     if (hours < 12) {
       summary.morning++;
+      console.log(`Classified as morning: ${slot.time}`);
     } else if (hours < 17) {
       summary.afternoon++;
+      console.log(`Classified as afternoon: ${slot.time}`);
     } else {
       summary.evening++;
+      console.log(`Classified as evening: ${slot.time}`);
     }
     summary.total++;
     
@@ -44,9 +51,9 @@ function getSlotSummary(slots: TimeSlot[]): SlotSummary {
   }, { total: 0, morning: 0, afternoon: 0, evening: 0 });
 }
 
-export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
+export default function ParksMap({ parks, selectedDate, onParkClick }: ParksMapProps) {
   const [mounted, setMounted] = useState(false);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [expandedParkId, setExpandedParkId] = useState<string | null>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -84,6 +91,16 @@ export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
 
   const selectedDateStr = format(selectedDate, 'yyyy-MM-dd');
 
+  const handleMarkerClick = (parkId: string) => {
+    if (expandedParkId === parkId) {
+      // If marker is already expanded, clicking again will scroll to details
+      onParkClick?.(parkId);
+    } else {
+      // First click just expands the popup
+      setExpandedParkId(parkId);
+    }
+  };
+
   return (
     <div className="relative w-full h-[400px] rounded-lg overflow-hidden shadow-lg">
       <MapContainer
@@ -106,7 +123,7 @@ export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
               position={[park.latitude, park.longitude]}
               icon={customIcon}
               eventHandlers={{
-                click: () => onParkClick?.(park.id),
+                click: () => handleMarkerClick(park.id),
               }}
             >
               <Popup>

--- a/src/components/ParksMap.tsx
+++ b/src/components/ParksMap.tsx
@@ -4,10 +4,49 @@ import { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { Park, ParksMapProps } from '@/types';
+import { Park, ParksMapProps, TimeSlot } from '@/types';
+import { format } from 'date-fns';
+
+interface SlotSummary {
+  total: number;
+  morning: number;   // Before 12:00
+  afternoon: number; // 12:00 - 16:59
+  evening: number;   // 17:00 onwards
+}
+
+function getSlotSummary(slots: TimeSlot[]): SlotSummary {
+  return slots.reduce((summary, slot) => {
+    // Parse time like "6:00 a.m." or "2:30 p.m."
+    const timeComponents = slot.time.toLowerCase().split(' ');
+    const timeStr = timeComponents[0];
+    const period = timeComponents[1]; // Will be "a.m." or "p.m."
+    
+    let [hours, minutes] = timeStr.split(':').map(Number);
+    
+    // Convert to 24-hour format
+    if (period === 'p.m.' && hours !== 12) {
+      hours += 12;
+    } else if (period === 'a.m.' && hours === 12) {
+      hours = 0;
+    }
+
+    // Classify slots
+    if (hours < 12) {
+      summary.morning++;
+    } else if (hours < 17) {
+      summary.afternoon++;
+    } else {
+      summary.evening++;
+    }
+    summary.total++;
+    
+    return summary;
+  }, { total: 0, morning: 0, afternoon: 0, evening: 0 });
+}
 
 export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
   const [mounted, setMounted] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
 
   useEffect(() => {
     setMounted(true);
@@ -43,6 +82,8 @@ export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
 
   if (!mounted) return null;
 
+  const selectedDateStr = format(selectedDate, 'yyyy-MM-dd');
+
   return (
     <div className="relative w-full h-[400px] rounded-lg overflow-hidden shadow-lg">
       <MapContainer
@@ -55,23 +96,64 @@ export default function ParksMap({ parks, onParkClick }: ParksMapProps) {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {parks.map((park) => (
-          <Marker
-            key={park.id}
-            position={[park.latitude, park.longitude]}
-            icon={customIcon}
-            eventHandlers={{
-              click: () => onParkClick?.(park.id),
-            }}
-          >
-            <Popup>
-              <div className="p-2 min-w-[200px]">
-                <h3 className="font-bold text-sm">{park.name}</h3>
-                <p className="text-xs text-gray-600 mt-1">{park.address}</p>
-              </div>
-            </Popup>
-          </Marker>
-        ))}
+        {parks.map((park) => {
+          const dateSlots = park.availableSlots[selectedDateStr] || [];
+          const summary = getSlotSummary(dateSlots);
+
+          return (
+            <Marker
+              key={park.id}
+              position={[park.latitude, park.longitude]}
+              icon={customIcon}
+              eventHandlers={{
+                click: () => onParkClick?.(park.id),
+              }}
+            >
+              <Popup>
+                <div className="p-3 min-w-[250px]">
+                  <h3 className="font-bold text-sm mb-2">{park.name}</h3>
+                  <p className="text-xs text-gray-600 mb-2">{park.address}</p>
+                  
+                  <div className="mt-3 space-y-1 text-sm">
+                    <div className={`font-semibold ${summary.total > 0 ? 'text-green-600' : 'text-gray-600'}`}>
+                      {summary.total > 0 ? (
+                        `${summary.total} Available Slots on ${format(selectedDate, 'MMMM d, yyyy')}`
+                      ) : (
+                        `No available slots on ${format(selectedDate, 'MMMM d, yyyy')}`
+                      )}
+                    </div>
+                    {summary.total > 0 && (
+                      <div className="grid grid-cols-3 gap-2 mt-2 text-xs">
+                        <div className="bg-yellow-50 p-2 rounded" title="6:00 a.m. - 11:59 a.m.">
+                          <div className="font-medium text-yellow-800">Morning</div>
+                          <div className="text-yellow-600">{summary.morning} slots</div>
+                        </div>
+                        <div className="bg-blue-50 p-2 rounded" title="12:00 p.m. - 4:59 p.m.">
+                          <div className="font-medium text-blue-800">Afternoon</div>
+                          <div className="text-blue-600">{summary.afternoon} slots</div>
+                        </div>
+                        <div className="bg-purple-50 p-2 rounded" title="5:00 p.m. - onwards">
+                          <div className="font-medium text-purple-800">Evening</div>
+                          <div className="text-purple-600">{summary.evening} slots</div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  <button 
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onParkClick?.(park.id);
+                    }}
+                    className="mt-3 w-full text-xs bg-blue-500 hover:bg-blue-600 text-white py-2 px-3 rounded transition-colors"
+                  >
+                    View Full Details
+                  </button>
+                </div>
+              </Popup>
+            </Marker>
+          );
+        })}
       </MapContainer>
     </div>
   );

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ArrowUpIcon } from '@heroicons/react/24/outline';
+
+export default function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // Show button when page is scrolled up to given distance
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-4 right-4 bg-blue-600 text-white p-3 rounded-full shadow-lg hover:bg-blue-700 transition-colors duration-200 z-50"
+      aria-label="Scroll to top"
+    >
+      <ArrowUpIcon className="h-6 w-6" />
+    </button>
+  );
+} 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,5 +38,6 @@ export interface ScrapeResult {
 
 export interface ParksMapProps {
   parks: Park[];
+  selectedDate: Date;
   onParkClick?: (parkId: string) => void;
 } 


### PR DESCRIPTION
     # Added Map Navigation Features

     ## Changes
     - Added slot summaries to map markers showing morning/afternoon/evening breakdown
     - Added "Scroll to Top" button that appears when scrolling down
     - Added "Go back to map" button in each park section
     - Fixed map marker click behavior (show popup first, then scroll to details)

     ## Testing
     - [ ] Verify slot summaries show correct counts
     - [ ] Check "Scroll to Top" appears after scrolling down
     - [ ] Test "Go back to map" button works smoothly
     - [ ] Verify map marker interactions work as expected